### PR TITLE
id-missing rule did not look for intl.formatMessage usage

### DIFF
--- a/lib/util/findNodes.js
+++ b/lib/util/findNodes.js
@@ -6,12 +6,22 @@
  * @returns {Object} node - returns node if it finds the attribute.
  */
 function findFormatMessageAttrNode(node, attrName) {
+  // Find formatMessage usages
   if (
     node.type === 'CallExpression'
     && node.callee.name === 'formatMessage') {
     if (node.arguments.length && node.arguments[0].properties) {
       return node.arguments[0].properties.find(a => a.key && a.key.name === attrName);
     }
+  }
+
+  // Find intl.formatMessage usages
+  if (
+    node.type === 'CallExpression'
+    && node.callee.type === 'MemberExpression'
+    && node.callee.object.name === 'intl'
+    && node.callee.property.name === 'formatMessage') {
+    return node.arguments[0].properties.find(a => a.key && a.key.name === attrName);
   }
 }
 

--- a/tests/lib/rules/id-missing.spec.js
+++ b/tests/lib/rules/id-missing.spec.js
@@ -111,6 +111,21 @@ ruleTester.run('id-missing', rule, {
       errors: ['Missing id pattern: in_b_*_missing']
     },
     {
+      code: "intl.formatMessage({ id: 'in_a_missing_example' })",
+      settings,
+      errors: ['Missing id: in_a_missing_example']
+    },
+    {
+      code: "intl.formatMessage({ id: 'bad_missing_example' })",
+      settings,
+      errors: ['Missing id: bad_missing_example']
+    },
+    {
+      code: 'intl.formatMessage({ id: `in_b_${bogus}_missing` })',
+      settings,
+      errors: ['Missing id pattern: in_b_*_missing']
+    },
+    {
       code: "defineMessages({ msg1: { id: `in_a_${bogus}_missing` }, msg2: { id: 'bad_missing_example' }})",
       settings,
       errors: ['Missing id pattern: in_a_*_missing', 'Missing id: bad_missing_example']


### PR DESCRIPTION
This update resolves the issue from https://github.com/godaddy/eslint-plugin-react-intl/issues/4