### PR TITLE
Remove legacy Slack references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,11 @@ submitting pull requests. To get involved you can, report or triage bugs and par
 discussions on the evolution of each project.
 
 No matter how you want to get involved, we ask that you first learn what’s expected of anyone who
-participates in the project by reading the Contribution Guidelines.
-
-**Please Note:** GitHub is for bug reports and contributions primarily - if you have a support
-question head over to [GoDaddy's Open Source Software Slack channel][slack].
+participates in the project by reading the Contribution Guidelines. 
 
 ## Answering Questions
 
-One of the most important and immediate ways you can support this project is to answer questions on [Slack][slack] or
+One of the most important and immediate ways you can support this project is to  or
 [Github][issues]. Whether you’re helping a newcomer understand a feature or troubleshooting an edge case with a
 seasoned developer, your knowledge and experience with JS can go a long way to help others.
 
@@ -49,7 +46,7 @@ From a practical perspective, contributions are as simple as:
 - Push the changes to your fork and submit a pull request to the 'master' branch of the projects' repository.
 
 If you are interested in making a large change and feel unsure about its overall effect,
-please make sure to first discuss the change and reach a consensus with core contributors through [slack].
+please make sure to first discuss the change and reach a consensus with core contributors.
 Then ask about the best way to go about making the change.
 
 ## Code Review
@@ -67,8 +64,7 @@ Here are some accepted ways to speed up review times for your patches:
   Goodwill is our currency.
 - Split your change into multiple smaller changes. The smaller your change, the higher the probability that
   somebody will take a quick look at it.
-- Ping the change on [slack]. If it is urgent, provide reasons why it is important to get this change landed.
-  Remember that you’re asking for valuable time from other professional developers.
+-  Remember that you’re asking for valuable time from other professional developers.
 
 **Note that anyone is welcome to review and give feedback on a change, but only people with commit access
 to the repository can approve it.**
@@ -92,7 +88,6 @@ set by [JSDoc]. Finally, please stick to the code style as defined by the [Godad
 - [JSDoc]
 
 [issues]: https://github.com/godaddy/eslint-plugin-react-intl/issues
-[slack]: https://godaddy-oss.slack.com/messages/CHXEP5DNH
 [JSDoc]: http://usejsdoc.org/
 [npm]: http://npmjs.org/
 [style]: https://github.com/godaddy/javascript/#godaddy-style


### PR DESCRIPTION
Contributions and questions should now be handled in GitHub Issues and Discussions.